### PR TITLE
Update PaymentData.php

### DIFF
--- a/src/PaymentData.php
+++ b/src/PaymentData.php
@@ -233,7 +233,7 @@ class Pronamic_WP_Pay_Extensions_WooCommerce_PaymentData extends Pronamic_WP_Pay
 	}
 
 	public function get_cancel_url() {
-		return $this->order->get_cancel_order_url();
+		return str_replace('&amp;', '&', $this->order->get_cancel_order_url());
 	}
 
 	public function get_success_url() {


### PR DESCRIPTION
L236: Replacing `&amp;` with `&` in WooCommerce's `get_cancel_order_url()` solves an issue with users getting an error 403 (probably due to security settings on the server) after cancellation of orders (e.g. after the payment has been cancelled).